### PR TITLE
Add streamlit app with calendar and images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # hub
+
 personal hub
+
+## Streamlit App
+
+Run the app with:
+
+```bash
+streamlit run app.py
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,15 @@
+import streamlit as st
+
+st.title("Kalender en Afbeeldingen")
+
+st.write("Selecteer een datum:")
+selected_date = st.date_input("Datum")
+
+st.write("## Gezin")
+st.image("https://loremflickr.com/400/300/family", caption="Gezin")
+
+st.write("## Moeder")
+st.image("https://loremflickr.com/400/300/mother", caption="Moeder")
+
+st.write("## Lover")
+st.image("https://loremflickr.com/400/300/lovers", caption="Lover")


### PR DESCRIPTION
## Summary
- add simple Streamlit `app.py` with a date picker and three themed images
- document how to run the Streamlit app in `README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a25ad2fc832a91fd65b21321a8a6